### PR TITLE
fix: prevent MessageInput cursor jump caused by Zustand store re-renders

### DIFF
--- a/frontend/src/components/Messages/DMConversation.tsx
+++ b/frontend/src/components/Messages/DMConversation.tsx
@@ -188,6 +188,14 @@ export function DMConversation({ userId, userName, userAvatar }: DMConversationP
     updateReplyCount(messageId, userId, count, participant);
   }, [updateReplyCount, userId, currentUser]);
 
+  // Stabilize onSend callback to prevent MessageInput re-renders
+  const handleSendDM = useCallback(
+    async (content: string, fileIds?: number[]) => {
+      await storeSendMessage(userId, content, fileIds);
+    },
+    [userId, storeSendMessage]
+  );
+
   // Close thread panel when switching conversations
   useEffect(() => {
     setActiveThreadId(null);
@@ -526,7 +534,7 @@ export function DMConversation({ userId, userName, userAvatar }: DMConversationP
           {/* Input */}
           <MessageInput
             placeholder={`Message ${userName}`}
-            onSend={async (content, fileIds) => { await storeSendMessage(userId, content, fileIds); }}
+            onSend={handleSendDM}
             sendError={sendError}
             clearSendError={clearSendError}
             dmParticipantIds={currentUser ? [currentUser.id, userId] : [userId]}

--- a/frontend/src/components/Messages/MessageArea.tsx
+++ b/frontend/src/components/Messages/MessageArea.tsx
@@ -50,6 +50,16 @@ export function MessageArea() {
     }));
   }, []);
 
+  // Stabilize onSend callback to prevent MessageInput re-renders
+  const handleSendMessage = useCallback(
+    async (content: string, fileIds?: number[]) => {
+      if (activeChannelId) {
+        await sendMessage(activeChannelId, content, fileIds);
+      }
+    },
+    [activeChannelId, sendMessage]
+  );
+
   // Show DM conversation if a DM is active
   if (activeDMId && activeDM) {
     return <DMConversation userId={activeDM.userId} userName={activeDM.userName} userAvatar={activeDM.userAvatar || undefined} />;
@@ -122,7 +132,7 @@ export function MessageArea() {
         ) : (
           <MessageInput
             placeholder={`Message #${activeChannel.name}`}
-            onSend={(content, fileIds) => sendMessage(activeChannelId!, content, fileIds)}
+            onSend={handleSendMessage}
             sendError={sendError}
             clearSendError={clearSendError}
             channelId={activeChannelId!}

--- a/frontend/src/components/Messages/MessageInput.tsx
+++ b/frontend/src/components/Messages/MessageInput.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, useState } from 'react';
+import React, { useRef, useEffect, useCallback, useState } from 'react';
 import {
   SendHorizontal,
   ChevronDown,
@@ -38,7 +38,7 @@ interface MessageInputProps {
   testIdPrefix?: string;
 }
 
-export function MessageInput({ placeholder, onSend, sendError, clearSendError, channelId, dmParticipantIds, testIdPrefix }: MessageInputProps) {
+export const MessageInput = React.memo(function MessageInput({ placeholder, onSend, sendError, clearSendError, channelId, dmParticipantIds, testIdPrefix }: MessageInputProps) {
   const prefix = testIdPrefix ? `${testIdPrefix}-` : '';
 
   // Schedule message state
@@ -282,4 +282,4 @@ export function MessageInput({ placeholder, onSend, sendError, clearSendError, c
       )}
     </div>
   );
-}
+});


### PR DESCRIPTION
## Problem
The message input cursor was intermittently jumping to the beginning of the field during typing, approximately every 1-10 seconds. This also caused file uploads to fail mid-process.

## Root Cause
WebSocket events fire frequently (presence updates, member count changes) causing parent components to re-render. The onSend prop passed to MessageInput was an inline arrow function, creating a new function reference on every parent re-render. This caused MessageInput and its Quill editor to re-render unnecessarily, briefly losing focus and resetting the cursor position.

## Fix
Wrapped the onSend callbacks in useCallback in MessageArea.tsx and DMConversation.tsx so the function reference stays stable across parent re-renders. MessageInput no longer re-renders when unrelated WebSocket events update the parent store.

## Changes
- MessageArea.tsx — Added handleSendMessage with useCallback
- DMConversation.tsx — Added handleSendDM with useCallback

## Testing
Deployed on our server with active users. Cursor remains stable during typing while WebSocket events fire in the background.