### PR TITLE
feat: add channel member removal for channel owners and admins

### DIFF
--- a/backend/src/routes/channels.ts
+++ b/backend/src/routes/channels.ts
@@ -9,6 +9,7 @@ import { isUserOnline, getIO } from '../websocket/index.js';
 import { USER_SELECT_BASIC, USER_SELECT_FULL, MESSAGE_INCLUDE_FULL } from '../db/selects.js';
 import { parseIntParam } from '../utils/params.js';
 import { logError } from '../utils/logger.js';
+import { writeAuditLog } from '../utils/auditLog.js';
 
 const router = Router();
 
@@ -533,6 +534,132 @@ router.patch('/:id/members/:userId', authMiddleware, requireChannelMembership, a
     }
     logError('Update member role error', error);
     res.status(500).json({ error: 'Failed to update member role' });
+  }
+});
+
+// DELETE /channels/:id/members/:userId - Remove a member from a channel
+router.delete('/:id/members/:userId', authMiddleware, requireChannelMembership, async (req: AuthRequest, res: Response) => {
+  try {
+    const channelId = req.channelId!;
+    const targetUserId = parseIntParam(req.params.userId);
+    if (!targetUserId) {
+      res.status(400).json({ error: 'Invalid user ID' });
+      return;
+    }
+
+    const actorId = req.user!.userId;
+
+    // Cannot remove yourself - use the leave endpoint instead
+    if (actorId === targetUserId) {
+      res.status(400).json({ error: 'Cannot remove yourself from the channel. Use the leave endpoint instead.' });
+      return;
+    }
+
+    // Get channel details and check if archived
+    const channel = await prisma.channel.findUnique({
+      where: { id: channelId },
+      select: { archivedAt: true, createdBy: true, name: true },
+    });
+
+    if (!channel) {
+      res.status(404).json({ error: 'Channel not found' });
+      return;
+    }
+
+    if (channel.archivedAt) {
+      res.status(403).json({ error: 'This channel has been archived' });
+      return;
+    }
+
+    // Cannot remove the channel creator
+    if (channel.createdBy === targetUserId) {
+      res.status(403).json({ error: 'Cannot remove the channel creator' });
+      return;
+    }
+
+    // Get actor's channel membership
+    const actorMember = await prisma.channelMember.findUnique({
+      where: { userId_channelId: { userId: actorId, channelId } },
+    });
+
+    if (!actorMember) {
+      res.status(403).json({ error: 'You are not a member of this channel' });
+      return;
+    }
+
+    // Get target's channel membership
+    const targetMember = await prisma.channelMember.findUnique({
+      where: { userId_channelId: { userId: targetUserId, channelId } },
+    });
+
+    if (!targetMember) {
+      res.status(404).json({ error: 'User is not a member of this channel' });
+      return;
+    }
+
+    // Authorization logic:
+    // 1. Channel OWNER can remove anyone (except creator and themselves)
+    // 2. Channel MODERATOR can only remove MEMBERs (not OWNER/MODERATOR)
+    // 3. Channel MEMBER cannot remove anyone
+    // Note: Workspace admins should use /admin/channels/:id/members/:userId instead
+    const isChannelOwner = actorMember.role === 'OWNER';
+    const isChannelModerator = actorMember.role === 'MODERATOR';
+
+    if (!isChannelOwner && !isChannelModerator) {
+      res.status(403).json({ error: 'Only channel owners and moderators can remove members' });
+      return;
+    }
+
+    // If actor is MODERATOR, they can only remove MEMBERs
+    if (isChannelModerator && !isChannelOwner) {
+      if (targetMember.role !== 'MEMBER') {
+        res.status(403).json({ error: 'Moderators can only remove regular members' });
+        return;
+      }
+    }
+
+    // Use transaction to ensure atomicity
+    const result = await prisma.$transaction(async (tx) => {
+      await tx.channelMember.delete({
+        where: { userId_channelId: { userId: targetUserId, channelId } },
+      });
+      const memberCount = await tx.channelMember.count({ where: { channelId } });
+      return { memberCount };
+    });
+
+    // Emit WebSocket events
+    const io = getIO();
+    if (io) {
+      // Notify channel members about the removal (same event as voluntary leave)
+      io.to(`channel:${channelId}`).emit('channel:member-left', {
+        channelId,
+        userId: targetUserId,
+        memberCount: result.memberCount,
+      });
+      // Evict user's sockets from the channel room
+      io.in(`user:${targetUserId}`).socketsLeave(`channel:${channelId}`);
+    }
+
+    // Get target user name for audit log
+    const targetUser = await prisma.user.findUnique({
+      where: { id: targetUserId },
+      select: { name: true },
+    });
+
+    // Write audit log (fire-and-forget, non-blocking)
+    writeAuditLog({
+      action: 'channel.member_removed',
+      actorId,
+      targetType: 'channel',
+      targetId: channelId,
+      targetName: channel.name,
+      details: `Removed user: ${targetUser?.name || targetUserId}`,
+    });
+
+    res.json({ message: 'Member removed successfully' });
+  } catch (error) {
+    logError('Remove member error', error);
+    res.status(500).json({ error: 'Failed to remove member' });
   }
 });
 

--- a/frontend/src/components/Messages/MembersPanel.tsx
+++ b/frontend/src/components/Messages/MembersPanel.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useRef } from 'react';
-import { UserPlus } from 'lucide-react';
+import { UserPlus, X } from 'lucide-react';
 import { Avatar } from '@/components/ui/avatar';
-import { getChannelMembers, getUsers, addChannelMember, type ChannelMember, type AuthUser } from '@/lib/api';
+import { getChannelMembers, getUsers, addChannelMember, getChannel, type ChannelMember, type AuthUser } from '@/lib/api';
 import { getSocket } from '@/lib/socket';
 import { Button } from '@/components/ui/button';
 import { ProfileModal } from '@/components/ProfileModal';
 import { PanelHeader } from './PanelHeader';
 import { useChannelStore } from '@/stores/useChannelStore';
+import { useAdminStore } from '@/stores/useAdminStore';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 interface MembersPanelProps {
   channelId: number;
@@ -14,11 +16,18 @@ interface MembersPanelProps {
 }
 
 export function MembersPanel({ channelId, onClose }: MembersPanelProps) {
+  const { user: currentUser } = useAuthStore();
+  const channelStoreRemove = useChannelStore((s) => s.removeChannelMember);
+  const adminStoreRemove = useAdminStore((s) => s.removeChannelMember);
   const [members, setMembers] = useState<ChannelMember[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [showAddForm, setShowAddForm] = useState(false);
   const [profileUserId, setProfileUserId] = useState<number | null>(null);
+  const [channelCreatorId, setChannelCreatorId] = useState<number | null>(null);
+  const [currentUserChannelRole, setCurrentUserChannelRole] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<{ userId: number; userName: string } | null>(null);
+  const [removing, setRemoving] = useState(false);
 
   const fetchMembers = () => {
     setIsLoading(true);
@@ -35,7 +44,15 @@ export function MembersPanel({ channelId, onClose }: MembersPanelProps) {
 
   useEffect(() => {
     fetchMembers();
-  }, [channelId]);
+    // Fetch channel details to get creator and current user's role
+    getChannel(channelId).then((channel) => {
+      setChannelCreatorId(channel.createdBy ?? null);
+      const currentMember = channel.members.find((m) => m.userId === currentUser?.id);
+      setCurrentUserChannelRole(currentMember?.role ?? null);
+    }).catch(() => {
+      // Ignore error, user may not have access
+    });
+  }, [channelId, currentUser?.id]);
 
   // Listen for real-time presence updates
   useEffect(() => {
@@ -64,6 +81,77 @@ export function MembersPanel({ channelId, onClose }: MembersPanelProps) {
       socket.off('presence:update', handlePresenceUpdate);
     };
   }, []);
+
+  // Listen for member removal events (uses same event as voluntary leave)
+  useEffect(() => {
+    const socket = getSocket();
+    if (!socket) return;
+
+    const handleMemberLeft = (data: { channelId: number; userId: number; memberCount: number }) => {
+      if (data.channelId === channelId) {
+        fetchMembers(); // Refresh the member list
+      }
+    };
+
+    socket.on('channel:member-left', handleMemberLeft);
+    return () => {
+      socket.off('channel:member-left', handleMemberLeft);
+    };
+  }, [channelId]);
+
+  const handleRemoveMember = async (userId: number, userName: string) => {
+    setConfirmRemove({ userId, userName });
+  };
+
+  const confirmRemoveMember = async () => {
+    if (!confirmRemove || !currentUser) return;
+    setRemoving(true);
+    try {
+      // Workspace admins use admin endpoint, channel owners/mods use channel endpoint
+      const isWorkspaceAdmin = currentUser.role === 'ADMIN' || currentUser.role === 'OWNER';
+      if (isWorkspaceAdmin) {
+        await adminStoreRemove(channelId, confirmRemove.userId);
+      } else {
+        await channelStoreRemove(channelId, confirmRemove.userId);
+      }
+      setConfirmRemove(null);
+      // Member list will refresh via WebSocket channel:member-left event
+    } catch (error: any) {
+      alert(error.message || 'Failed to remove member');
+    } finally {
+      setRemoving(false);
+    }
+  };
+
+  // Determine if current user can remove members
+  const canRemoveMembers = () => {
+    if (!currentUser) return false;
+    const isWorkspaceAdmin = currentUser.role === 'ADMIN' || currentUser.role === 'OWNER';
+    const isChannelOwner = currentUserChannelRole === 'OWNER';
+    const isChannelModerator = currentUserChannelRole === 'MODERATOR';
+    return isWorkspaceAdmin || isChannelOwner || isChannelModerator;
+  };
+
+  // Check if a specific member can be removed by current user
+  const canRemoveMember = (member: ChannelMember) => {
+    if (!currentUser || !canRemoveMembers()) return false;
+    if (member.user.id === currentUser.id) return false; // Cannot remove self
+    if (member.user.id === channelCreatorId) return false; // Cannot remove creator
+
+    const isWorkspaceAdmin = currentUser.role === 'ADMIN' || currentUser.role === 'OWNER';
+    const isChannelOwner = currentUserChannelRole === 'OWNER';
+    const isChannelModerator = currentUserChannelRole === 'MODERATOR';
+
+    // Workspace admins and channel owners can remove anyone (except creator)
+    if (isWorkspaceAdmin || isChannelOwner) return true;
+
+    // Moderators can only remove regular members
+    if (isChannelModerator) {
+      return member.channelRole === 'MEMBER' || !member.channelRole;
+    }
+
+    return false;
+  };
 
   const onlineMembers = members.filter((m) => m.user.isOnline);
   const offlineMembers = members.filter((m) => !m.user.isOnline);
@@ -110,7 +198,12 @@ export function MembersPanel({ channelId, onClose }: MembersPanelProps) {
                   Online — {onlineMembers.length}
                 </h4>
                 {onlineMembers.map((m) => (
-                  <MemberRow key={m.user.id} member={m} onClick={() => setProfileUserId(m.user.id)} />
+                  <MemberRow
+                    key={m.user.id}
+                    member={m}
+                    onClick={() => setProfileUserId(m.user.id)}
+                    onRemove={canRemoveMember(m) ? () => handleRemoveMember(m.user.id, m.user.name) : undefined}
+                  />
                 ))}
               </div>
             )}
@@ -121,7 +214,12 @@ export function MembersPanel({ channelId, onClose }: MembersPanelProps) {
                   Offline — {offlineMembers.length}
                 </h4>
                 {offlineMembers.map((m) => (
-                  <MemberRow key={m.user.id} member={m} onClick={() => setProfileUserId(m.user.id)} />
+                  <MemberRow
+                    key={m.user.id}
+                    member={m}
+                    onClick={() => setProfileUserId(m.user.id)}
+                    onRemove={canRemoveMember(m) ? () => handleRemoveMember(m.user.id, m.user.name) : undefined}
+                  />
                 ))}
               </div>
             )}
@@ -130,6 +228,32 @@ export function MembersPanel({ channelId, onClose }: MembersPanelProps) {
       </div>
       {profileUserId !== null && (
         <ProfileModal userId={profileUserId} onClose={() => setProfileUserId(null)} />
+      )}
+      {confirmRemove && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white rounded-lg shadow-xl p-6 max-w-sm w-full mx-4">
+            <h3 className="text-lg font-semibold text-slack-primary mb-2">Remove member?</h3>
+            <p className="text-sm text-slack-secondary mb-4">
+              Remove <strong>{confirmRemove.userName}</strong> from this channel?
+            </p>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setConfirmRemove(null)}
+                disabled={removing}
+                className="px-4 py-2 text-sm rounded bg-slack-hover hover:bg-slack-border text-slack-primary disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmRemoveMember}
+                disabled={removing}
+                className="px-4 py-2 text-sm rounded bg-red-600 hover:bg-red-700 text-white disabled:opacity-50"
+              >
+                {removing ? 'Removing...' : 'Remove'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );
@@ -227,27 +351,46 @@ const CHANNEL_ROLE_BADGE: Record<string, { label: string; className: string } | 
   MODERATOR: { label: 'Mod', className: 'bg-indigo-100 text-indigo-700' },
 };
 
-function MemberRow({ member, onClick }: { member: ChannelMember; onClick?: () => void }) {
+function MemberRow({ member, onClick, onRemove }: { member: ChannelMember; onClick?: () => void; onRemove?: () => void }) {
   const roleBadge = member.channelRole ? CHANNEL_ROLE_BADGE[member.channelRole] : undefined;
+  const [showRemove, setShowRemove] = useState(false);
 
   return (
-    <button
+    <div
       data-testid={`member-row-${member.user.id}`}
-      onClick={onClick}
-      className="flex w-full items-center gap-2 rounded px-2 py-1.5 hover:bg-slack-hover cursor-pointer">
-      <Avatar
-        src={member.user.avatar}
-        alt={member.user.name}
-        fallback={member.user.name}
-        size="sm"
-        status={member.user.isOnline ? 'online' : 'offline'}
-      />
-      <span className="text-[14px] text-slack-primary truncate">{member.user.name}</span>
-      {roleBadge && (
-        <span className={`ml-auto shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${roleBadge.className}`}>
-          {roleBadge.label}
-        </span>
+      className="relative group"
+      onMouseEnter={() => setShowRemove(true)}
+      onMouseLeave={() => setShowRemove(false)}
+    >
+      <button
+        onClick={onClick}
+        className="flex w-full items-center gap-2 rounded px-2 py-1.5 hover:bg-slack-hover cursor-pointer">
+        <Avatar
+          src={member.user.avatar}
+          alt={member.user.name}
+          fallback={member.user.name}
+          size="sm"
+          status={member.user.isOnline ? 'online' : 'offline'}
+        />
+        <span className="text-[14px] text-slack-primary truncate">{member.user.name}</span>
+        {roleBadge && (
+          <span className={`ml-auto shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium ${roleBadge.className}`}>
+            {roleBadge.label}
+          </span>
+        )}
+      </button>
+      {onRemove && showRemove && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="absolute right-2 top-1/2 -translate-y-1/2 p-1 rounded hover:bg-red-100 text-slack-secondary hover:text-red-600"
+          title="Remove member"
+        >
+          <X className="h-4 w-4" />
+        </button>
       )}
-    </button>
+    </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -178,12 +178,27 @@ export interface ApiChannel {
   _count: { members: number; messages: number };
 }
 
+export interface ApiChannelDetail extends ApiChannel {
+  createdBy?: number | null;
+  members: Array<{
+    userId: number;
+    channelId: number;
+    role: 'OWNER' | 'MODERATOR' | 'MEMBER';
+    joinedAt: string;
+    user: {
+      id: number;
+      name: string;
+      avatar?: string | null;
+    };
+  }>;
+}
+
 export function getChannels() {
   return request<ApiChannel[]>('/channels');
 }
 
 export function getChannel(id: number) {
-  return request<ApiChannel>(`/channels/${id}`);
+  return request<ApiChannelDetail>(`/channels/${id}`);
 }
 
 export function createChannel(name: string, isPrivate = false) {
@@ -611,6 +626,12 @@ export function addChannelMember(channelId: number, userId: number) {
   });
 }
 
+export function removeChannelMember(channelId: number, userId: number) {
+  return request<{ message: string }>(`/channels/${channelId}/members/${userId}`, {
+    method: 'DELETE',
+  });
+}
+
 // ---- Scheduled Messages ----
 
 export interface ApiScheduledMessage {
@@ -745,6 +766,12 @@ export function adminEditChannel(channelId: number, data: { name?: string; isPri
   return request<AdminChannel>(`/admin/channels/${channelId}`, {
     method: 'PATCH',
     body: JSON.stringify(data),
+  });
+}
+
+export function adminRemoveChannelMember(channelId: number, userId: number) {
+  return request<{ message: string }>(`/admin/channels/${channelId}/members/${userId}`, {
+    method: 'DELETE',
   });
 }
 

--- a/frontend/src/stores/useAdminStore.ts
+++ b/frontend/src/stores/useAdminStore.ts
@@ -24,6 +24,7 @@ interface AdminState {
   archiveChannel: (channelId: number) => Promise<void>;
   unarchiveChannel: (channelId: number) => Promise<void>;
   editChannel: (channelId: number, data: { name?: string; isPrivate?: boolean }) => Promise<void>;
+  removeChannelMember: (channelId: number, userId: number) => Promise<void>;
 }
 
 export const useAdminStore = create<AdminState>((set, get) => ({
@@ -171,6 +172,16 @@ export const useAdminStore = create<AdminState>((set, get) => ({
       set({ channels: get().channels.map((c) => (c.id === channelId ? updated : c)) });
     } catch (err) {
       set({ channels: prev, error: err instanceof Error ? err.message : 'Failed to edit channel' });
+    }
+  },
+
+  removeChannelMember: async (channelId, userId) => {
+    try {
+      await api.adminRemoveChannelMember(channelId, userId);
+      // Member count will be updated via WebSocket channel:member-left event
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : 'Failed to remove channel member' });
+      throw err;
     }
   },
 

--- a/frontend/src/stores/useChannelStore.ts
+++ b/frontend/src/stores/useChannelStore.ts
@@ -42,6 +42,7 @@ interface ChannelState {
   createChannel: (name: string, isPrivate?: boolean) => Promise<number>;
   joinChannel: (channelId: number) => Promise<void>;
   leaveChannel: (channelId: number) => Promise<number | null>;
+  removeChannelMember: (channelId: number, userId: number) => Promise<void>;
   toggleStar: (channelId: number) => void;
   setActiveChannel: (channelId: number, scrollToMessageId?: number) => void;
   setActiveDM: (dmId: number, scrollToMessageId?: number) => void;
@@ -160,6 +161,16 @@ export const useChannelStore = create<ChannelState>((set, get) => ({
       return nextChannelId;
     } catch (err) {
       console.error('Failed to leave channel:', err);
+      throw err;
+    }
+  },
+
+  removeChannelMember: async (channelId: number, userId: number) => {
+    try {
+      await api.removeChannelMember(channelId, userId);
+      // Member count will be updated via WebSocket channel:member-left event
+    } catch (err) {
+      console.error('Failed to remove channel member:', err);
       throw err;
     }
   },


### PR DESCRIPTION
## Closes
Resolves #114

## Changes
Added the ability for channel owners/moderators and workspace admins to remove members from channels.

**Backend** — new `DELETE /channels/:id/members/:userId` endpoint in `channels.ts`:
- Channel OWNER can remove anyone except the creator
- Channel MODERATOR can only remove regular MEMBERs
- Cannot remove yourself (use leave endpoint) or the channel creator
- Emits `channel:member-left` (consistent with existing admin endpoint)
- Writes to audit log

**Frontend API** — added `removeChannelMember()` and `adminRemoveChannelMember()` in `api.ts`

**Stores** — added `removeChannelMember` action to both `useChannelStore` and `useAdminStore`

**UI** — updated `MembersPanel.tsx`:
- X button appears on hover, visible only to users with permission
- Workspace admins route to existing `/admin/channels/:id/members/:userId`
- Channel owners/mods route to new `/channels/:id/members/:userId`
- Confirmation modal before removal
- Member list refreshes after removal via `channel:member-left` WebSocket event

**Tested**
- Tested on my ec2 instance running Slawk - previously a user was in a Channel that I couldn't remove. I pulled and rebuilt the image and I was able to remove him with this branch.