### PR TITLE
fix: memoize MessageInput props to prevent cursor jump during WebSocket events

### DIFF
--- a/frontend/src/components/Messages/DMConversation.tsx
+++ b/frontend/src/components/Messages/DMConversation.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, useCallback, useMemo } from 'react';
 import { format, isToday, isYesterday } from 'date-fns';
 import {
   Pin,
@@ -223,6 +223,15 @@ export function DMConversation({ userId, userName, userAvatar }: DMConversationP
   useEffect(() => {
     setActiveThreadId(null);
   }, [userId]);
+
+  // Memoize dmParticipantIds to prevent MessageInput re-renders
+  const dmParticipantIds = useMemo(
+    () => (currentUser ? [currentUser.id, userId] : [userId]),
+    [currentUser?.id, userId]
+  );
+
+  // Memoize placeholder to prevent MessageInput re-renders
+  const placeholder = useMemo(() => `Message ${userName}`, [userName]);
 
   return (
     <div data-testid="dm-conversation" className="flex h-full flex-col">
@@ -572,11 +581,11 @@ export function DMConversation({ userId, userName, userAvatar }: DMConversationP
 
           {/* Input */}
           <MessageInput
-            placeholder={`Message ${userName}`}
+            placeholder={placeholder}
             onSend={handleSendDM}
             sendError={sendError}
             clearSendError={clearSendError}
-            dmParticipantIds={currentUser ? [currentUser.id, userId] : [userId]}
+            dmParticipantIds={dmParticipantIds}
             testIdPrefix="dm"
           />
         </div>

--- a/frontend/src/components/Messages/MessageArea.tsx
+++ b/frontend/src/components/Messages/MessageArea.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import { Hash, Menu } from 'lucide-react';
 import { useMobileStore } from '@/stores/useMobileStore';
 import { useChannelStore } from '@/stores/useChannelStore';
@@ -58,6 +58,12 @@ export function MessageArea() {
       }
     },
     [activeChannelId, sendMessage]
+  );
+
+  // Memoize placeholder to prevent MessageInput re-renders
+  const placeholder = useMemo(
+    () => (activeChannel ? `Message #${activeChannel.name}` : ''),
+    [activeChannel?.name]
   );
 
   // Show DM conversation if a DM is active
@@ -131,7 +137,7 @@ export function MessageArea() {
           </div>
         ) : (
           <MessageInput
-            placeholder={`Message #${activeChannel.name}`}
+            placeholder={placeholder}
             onSend={handleSendMessage}
             sendError={sendError}
             clearSendError={clearSendError}


### PR DESCRIPTION
## Problem
The message input cursor was intermittently jumping to the beginning of the field during typing. This was a follow-up issue after React.memo was added to MessageInput in #112.

## Root Cause
Two unstable prop references were defeating React.memo's shallow comparison:
1. `dmParticipantIds` in DMConversation.tsx was a new array created inline on every render
2. `placeholder` template literals in both MessageArea.tsx and DMConversation.tsx were new string references on every render

WebSocket events (presence updates, member count changes) triggered parent re-renders, which passed new prop references to MessageInput, causing unnecessary re-renders and Quill editor focus loss.

## Fix
- Memoized `dmParticipantIds` with `useMemo` in DMConversation.tsx
- Memoized `placeholder` strings with `useMemo` in both MessageArea.tsx and DMConversation.tsx

## Files Changed
- `frontend/src/components/Messages/DMConversation.tsx`
- `frontend/src/components/Messages/MessageArea.tsx`