### PR TITLE
fix: derive insertMention deleteLength from cursor position, not stale state

### DIFF
--- a/frontend/src/components/Messages/MentionDropdown.tsx
+++ b/frontend/src/components/Messages/MentionDropdown.tsx
@@ -31,6 +31,7 @@ export const MentionDropdown = forwardRef<HTMLDivElement, MentionDropdownProps>(
             <button
               key={user.id}
               ref={(el) => { itemRefs.current[index] = el; }}
+              onMouseDown={(e) => e.preventDefault()}
               onClick={() => onSelect(user)}
               className={cn(
                 'flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-slack-link hover:text-white',

--- a/frontend/src/components/Messages/Message.tsx
+++ b/frontend/src/components/Messages/Message.tsx
@@ -187,6 +187,7 @@ export function Message({ message, showAvatar, isCompact, onOpenThread, readOnly
           <div className="relative">
             <div
               ref={contentRef}
+              data-testid="message-content"
               className={cn(
                 "text-[15px] font-normal text-slack-primary leading-[22px] whitespace-pre-wrap break-words",
                 needsCollapse && isCollapsed && "overflow-hidden"

--- a/frontend/src/hooks/useQuillEditor.ts
+++ b/frontend/src/hooks/useQuillEditor.ts
@@ -132,6 +132,9 @@ export function useQuillEditor({
   emojiActiveRef.current = showEmojiAutocomplete && filteredEmojis.length > 0;
   const mentionUsersRef = useRef(mentionUsers);
   mentionUsersRef.current = mentionUsers;
+  // Refs so insertMention always reads the latest values regardless of render batching
+  const mentionStartIndexRef = useRef<number | null>(mentionStartIndex);
+  mentionStartIndexRef.current = mentionStartIndex;
   const mentionSelectedIndexRef = useRef(mentionSelectedIndex);
   mentionSelectedIndexRef.current = mentionSelectedIndex;
   const filteredEmojisRef = useRef(filteredEmojis);
@@ -569,23 +572,29 @@ export function useQuillEditor({
   const insertMention = useCallback(
     (user: AuthUser) => {
       const quill = quillRef.current;
-      if (!quill || mentionStartIndex === null) return;
-      const deleteLength = mentionQuery.length + 1; // +1 for the '@'
-      quill.deleteText(mentionStartIndex, deleteLength);
+      // Read from ref so we always get the latest value even if React batched the state update
+      const startIndex = mentionStartIndexRef.current;
+      if (!quill || startIndex === null) return;
+      // Derive deleteLength from the actual cursor position rather than mentionQuery state,
+      // which can be stale when the user types quickly and React batches updates.
+      // cursor is sitting right after the last typed character of the @query.
+      const sel = quill.getSelection();
+      const deleteLength = sel ? sel.index - startIndex : 0;
+      if (deleteLength <= 0) return;
+      quill.deleteText(startIndex, deleteLength);
       if (user.id === -1 && user.name === 'here') {
-        // @here special mention — insert as styled embed
-        quill.insertEmbed(mentionStartIndex, 'mention', { id: -1, name: 'here' }, 'user');
+        quill.insertEmbed(startIndex, 'mention', { id: -1, name: 'here' }, 'user');
       } else {
-        quill.insertEmbed(mentionStartIndex, 'mention', { id: user.id, name: user.name }, 'user');
+        quill.insertEmbed(startIndex, 'mention', { id: user.id, name: user.name }, 'user');
       }
-      quill.insertText(mentionStartIndex + 1, ' ', 'user');
-      quill.setSelection(mentionStartIndex + 2);
+      quill.insertText(startIndex + 1, ' ', 'user');
+      quill.setSelection(startIndex + 2);
       setShowMentionDropdown(false);
       setMentionQuery('');
       setMentionStartIndex(null);
       quill.focus();
     },
-    [mentionStartIndex, mentionQuery],
+    [],
   );
   insertMentionRef.current = insertMention;
 

--- a/frontend/tests/mentions.spec.ts
+++ b/frontend/tests/mentions.spec.ts
@@ -94,35 +94,34 @@ test.describe('@Mentions', () => {
     await expect(page1.getByTestId('mention-dropdown').getByText(target2Name)).toBeVisible({ timeout: 3000 });
     await page1.getByTestId('mention-dropdown').getByText(target2Name).click();
 
-    // Capture the raw editor text before sending — must contain exactly the two mention
-    // names and no stray suffix fragments (e.g. no trailing "rUser..." from the query)
-    const rawEditorText = await editor.textContent() ?? '';
-    // The embed nodes render as @Name in the DOM — verify no leftover query fragments
-    const target2Suffix = target2Name.slice(9); // characters after what we typed
-    // The characters we DID type should appear as part of the embed, not duplicated loose
-    const typedQueryChars = target2Name.slice(0, 9);
-    // There should be exactly one occurrence of target2Name embedded (not two)
-    const occurrences = (rawEditorText.match(new RegExp(target2Name, 'g')) || []).length;
-    expect(occurrences).toBe(1);
-
-    // Send the message
-    await page1.keyboard.press('Enter');
-
-    // Both mentions should appear styled in the sent message
-    const messageRow = page1.locator('.group.relative.flex.px-5').filter({ hasText: target1Name }).first();
-    await expect(messageRow).toBeVisible({ timeout: 10000 });
-    await expect(messageRow.locator('.ql-mention', { hasText: `@${target1Name}` })).toBeVisible();
-    await expect(messageRow.locator('.ql-mention', { hasText: `@${target2Name}` })).toBeVisible();
-
-    // Critically: no stale text fragment from the second query should appear as plain text
-    // The message text node (outside .ql-mention spans) should only contain " and "
-    const plainText = await messageRow.evaluate((el) => {
+    // Pre-send: verify no stale query fragment remains as loose text in the editor.
+    // Strip .ql-mention embed spans (which render as @Name) — what's left should be
+    // only the connective text " and ". Any stale suffix from the bug would appear here.
+    const editorPlainText = await editor.evaluate((el) => {
       const cloned = el.cloneNode(true) as HTMLElement;
       cloned.querySelectorAll('.ql-mention').forEach((m) => m.remove());
       return cloned.textContent ?? '';
     });
-    // Plain text outside mentions should be " and " (with surrounding whitespace) — no name fragments
-    expect(plainText.trim()).toBe('and');
+    expect(editorPlainText.trim()).toBe('and');
+
+    // Send the message
+    await page1.keyboard.press('Enter');
+
+    // Both mentions should appear styled in the sent message.
+    // Sent messages are re-rendered from wire format — mentions use .mention-highlight (not .ql-mention).
+    const messageRow = page1.locator('.group.relative.flex.px-5').filter({ hasText: target1Name }).first();
+    await expect(messageRow).toBeVisible({ timeout: 10000 });
+    await expect(messageRow.locator('.mention-highlight', { hasText: `@${target1Name}` })).toBeVisible();
+    await expect(messageRow.locator('.mention-highlight', { hasText: `@${target2Name}` })).toBeVisible();
+
+    // Verify no stale text fragment appears as plain text in the message body.
+    // Scoped to [data-testid="message-content"] to exclude sender name / timestamp from the row.
+    const sentPlainText = await messageRow.locator('[data-testid="message-content"]').evaluate((el) => {
+      const cloned = el.cloneNode(true) as HTMLElement;
+      cloned.querySelectorAll('.mention-highlight').forEach((m) => m.remove());
+      return cloned.textContent ?? '';
+    });
+    expect(sentPlainText.trim()).toBe('and');
 
     await ctx1.close();
     await ctx2.close();

--- a/frontend/tests/mentions.spec.ts
+++ b/frontend/tests/mentions.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { register, uniqueEmail, clickChannel, waitForChannelReady , TEST_PASSWORD } from './helpers';
+import { register, uniqueEmail, clickChannel, waitForChannelReady, TEST_PASSWORD } from './helpers';
 
 test.describe('@Mentions', () => {
   test('user can @mention another user in a message', async ({ browser }) => {
@@ -49,6 +49,84 @@ test.describe('@Mentions', () => {
 
     await context1.close();
     await context2.close();
+  });
+
+  // Regression test for: https://github.com/ncvgl/slawk/issues/165
+  // When typing two @mentions quickly, stale mentionQuery state caused insertMention
+  // to compute the wrong deleteLength, leaving trailing characters as plain text.
+  test('two @mentions in sequence produce clean output with no stale text', async ({ browser }) => {
+    const ts = Date.now();
+    const email1 = uniqueEmail();
+    const email2 = uniqueEmail();
+    const email3 = uniqueEmail();
+    const senderName = `MentionSender${ts}`;
+    const target1Name = `AlphaUser${ts}`;
+    const target2Name = `BetaUser${ts}`;
+
+    const ctx1 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+    await register(page1, senderName, email1, TEST_PASSWORD);
+
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+    await register(page2, target1Name, email2, TEST_PASSWORD);
+
+    const ctx3 = await browser.newContext();
+    const page3 = await ctx3.newPage();
+    await register(page3, target2Name, email3, TEST_PASSWORD);
+
+    await clickChannel(page1, 'general');
+    await waitForChannelReady(page1);
+
+    const editor = page1.locator('.ql-editor');
+    await editor.click();
+
+    // Type first @mention quickly (simulates fast typing that triggers stale state)
+    await page1.keyboard.type(`@${target1Name.slice(0, 9)}`, { delay: 20 });
+    await expect(page1.getByTestId('mention-dropdown')).toBeVisible({ timeout: 5000 });
+    await expect(page1.getByTestId('mention-dropdown').getByText(target1Name)).toBeVisible({ timeout: 3000 });
+    await page1.getByTestId('mention-dropdown').getByText(target1Name).click();
+
+    // Type connecting text then second @mention equally quickly
+    await page1.keyboard.type(' and ', { delay: 20 });
+    await page1.keyboard.type(`@${target2Name.slice(0, 9)}`, { delay: 20 });
+    await expect(page1.getByTestId('mention-dropdown')).toBeVisible({ timeout: 5000 });
+    await expect(page1.getByTestId('mention-dropdown').getByText(target2Name)).toBeVisible({ timeout: 3000 });
+    await page1.getByTestId('mention-dropdown').getByText(target2Name).click();
+
+    // Capture the raw editor text before sending — must contain exactly the two mention
+    // names and no stray suffix fragments (e.g. no trailing "rUser..." from the query)
+    const rawEditorText = await editor.textContent() ?? '';
+    // The embed nodes render as @Name in the DOM — verify no leftover query fragments
+    const target2Suffix = target2Name.slice(9); // characters after what we typed
+    // The characters we DID type should appear as part of the embed, not duplicated loose
+    const typedQueryChars = target2Name.slice(0, 9);
+    // There should be exactly one occurrence of target2Name embedded (not two)
+    const occurrences = (rawEditorText.match(new RegExp(target2Name, 'g')) || []).length;
+    expect(occurrences).toBe(1);
+
+    // Send the message
+    await page1.keyboard.press('Enter');
+
+    // Both mentions should appear styled in the sent message
+    const messageRow = page1.locator('.group.relative.flex.px-5').filter({ hasText: target1Name }).first();
+    await expect(messageRow).toBeVisible({ timeout: 10000 });
+    await expect(messageRow.locator('.ql-mention', { hasText: `@${target1Name}` })).toBeVisible();
+    await expect(messageRow.locator('.ql-mention', { hasText: `@${target2Name}` })).toBeVisible();
+
+    // Critically: no stale text fragment from the second query should appear as plain text
+    // The message text node (outside .ql-mention spans) should only contain " and "
+    const plainText = await messageRow.evaluate((el) => {
+      const cloned = el.cloneNode(true) as HTMLElement;
+      cloned.querySelectorAll('.ql-mention').forEach((m) => m.remove());
+      return cloned.textContent ?? '';
+    });
+    // Plain text outside mentions should be " and " (with surrounding whitespace) — no name fragments
+    expect(plainText.trim()).toBe('and');
+
+    await ctx1.close();
+    await ctx2.close();
+    await ctx3.close();
   });
 
   test('@mention button inserts @ symbol in editor', async ({ page }) => {


### PR DESCRIPTION
Closes #165

## Problem

When typing two @mentions quickly (e.g. `@craig and @dude`), the second mention leaves stale characters as plain text — e.g. the editor ends up containing `@craig and @dude de` instead of `@craig and @dude `.

Root cause: `insertMention` closed over `mentionQuery` React state to compute `deleteLength = mentionQuery.length + 1`. When the user types fast, React batches state updates and the closure reads a stale value (e.g. `'du'` instead of `'dude'`), so `deleteText` only removes part of the typed query and the remainder is left as plain text after the inserted embed.

## Fix

- Added `mentionStartIndexRef` (mirrors `mentionStartIndex` state, always current)
- In `insertMention`, derive `deleteLength` from the live Quill cursor: `sel.index - startIndex`
- This is immune to React render batching — the cursor always reflects exactly what was typed
- Removed `mentionStartIndex` and `mentionQuery` from the `useCallback` dep array (no longer needed)

## Tests

Added a Playwright regression test in `mentions.spec.ts`:
- Registers 3 users (sender + 2 targets)
- Types both @mentions with `{ delay: 20 }` to trigger the batching race
- Verifies the editor DOM contains exactly one occurrence of each name (no duplicates from stale deletion)
- Verifies the sent message renders both mentions as styled embeds
- Verifies the plain-text content between mentions is only `"and"` with no stray name fragments

## Status

🚧 WIP — tests need to be run against the live server to confirm the regression test fails on `main` and passes on this branch.