### PR TITLE
fix: derive emoji autocomplete deleteLength from cursor, not stale state

### DIFF
--- a/frontend/src/hooks/useQuillEditor.ts
+++ b/frontend/src/hooks/useQuillEditor.ts
@@ -141,6 +141,9 @@ export function useQuillEditor({
   filteredEmojisRef.current = filteredEmojis;
   const emojiSelectedIndexRef = useRef(emojiSelectedIndex);
   emojiSelectedIndexRef.current = emojiSelectedIndex;
+  // Ref so insertEmojiFromAutocomplete always reads the latest start index regardless of render batching
+  const emojiStartIndexRef = useRef<number | null>(emojiStartIndex);
+  emojiStartIndexRef.current = emojiStartIndex;
   const insertMentionRef = useRef<(user: AuthUser) => void>(() => {});
   const insertEmojiAutocompleteRef = useRef<(emoji: EmojiOption) => void>(() => {});
 
@@ -514,6 +517,10 @@ export function useQuillEditor({
     quill.root.addEventListener('drop', handleDrop as any);
 
     quillRef.current = quill;
+    // Expose the active editor for e2e tests (mirrors window.__socket). DEV/E2E only.
+    if (import.meta.env.DEV || import.meta.env.VITE_E2E) {
+      (window as any).__quill = quill;
+    }
   }, [placeholder, testId, enableInlineCode]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update placeholder when it changes
@@ -601,17 +608,25 @@ export function useQuillEditor({
   const insertEmojiFromAutocomplete = useCallback(
     (emoji: EmojiOption) => {
       const quill = quillRef.current;
-      if (!quill || emojiStartIndex === null) return;
-      const deleteLength = emojiQuery.length + 1; // +1 for the leading ':'
-      quill.deleteText(emojiStartIndex, deleteLength);
-      quill.insertText(emojiStartIndex, emoji.native);
-      quill.setSelection(emojiStartIndex + emoji.native.length);
+      // Read from ref so we always get the latest value even if React batched the state update
+      const startIndex = emojiStartIndexRef.current;
+      if (!quill || startIndex === null) return;
+      // Derive deleteLength from the actual cursor position rather than emojiQuery state,
+      // which can be stale when the user types quickly and React batches updates. The cursor
+      // sits right after the last typed character of the ':query', so the span to remove is
+      // everything from the leading ':' up to the cursor (covers the ':' plus the shortcode).
+      const sel = quill.getSelection();
+      const deleteLength = sel ? sel.index - startIndex : 0;
+      if (deleteLength <= 0) return;
+      quill.deleteText(startIndex, deleteLength);
+      quill.insertText(startIndex, emoji.native);
+      quill.setSelection(startIndex + emoji.native.length);
       setShowEmojiAutocomplete(false);
       setEmojiQuery('');
       setEmojiStartIndex(null);
       quill.focus();
     },
-    [emojiStartIndex, emojiQuery],
+    [],
   );
   insertEmojiAutocompleteRef.current = insertEmojiFromAutocomplete;
 

--- a/frontend/tests/emoji-autocomplete-enter.spec.ts
+++ b/frontend/tests/emoji-autocomplete-enter.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+import { register, uniqueEmail, clickChannel, waitForChannelReady, TEST_PASSWORD } from './helpers';
+
+test.describe('Emoji autocomplete', () => {
+  // Regression test: selecting an emoji from the autocomplete with Enter used to leave a
+  // stray trailing character (e.g. "...handoff🙏a"). insertEmojiFromAutocomplete computed
+  // deleteLength from the emojiQuery state, which lags behind the typed text when React
+  // batches updates during fast typing. Fixed by deriving the span to delete from the live
+  // Quill cursor position instead (mirrors the @mention fix in #166).
+  //
+  // The bug is a sub-task React state-batching race that Playwright's inter-keystroke delay
+  // lets resolve, so we reproduce it deterministically: type ":jo" (committing emojiQuery
+  // = "jo"), then within a single browser task insert the final "y" and dispatch Enter
+  // before React can re-render. On the buggy code the stale closure deletes only ":jo",
+  // leaving "y" after the emoji; the fix reads the live cursor and deletes ":joy".
+  test('selecting an emoji via Enter leaves no stray query characters', async ({ page }) => {
+    const ts = Date.now();
+    await register(page, `EmojiEnter${ts}`, uniqueEmail(), TEST_PASSWORD);
+
+    await clickChannel(page, 'general');
+    await waitForChannelReady(page);
+
+    const editor = page.locator('.ql-editor');
+    await editor.click();
+
+    // Type some text then a partial :shortcode. Wait for the autocomplete so the emojiQuery
+    // state ("jo") and emojiStartIndex are committed in React.
+    await page.keyboard.type('handoff ', { delay: 20 });
+    await page.keyboard.type(':jo', { delay: 20 });
+    await expect(page.getByTestId('emoji-autocomplete')).toBeVisible({ timeout: 5000 });
+
+    // In a single JS task: append the final query char (schedules setEmojiQuery('joy') but
+    // does not flush it) then synchronously fire Enter. The keyboard handler runs against the
+    // not-yet-updated closure — exactly the race a fast typist hits.
+    await page.evaluate(() => {
+      const q = (window as any).__quill;
+      q.focus();
+      const sel = q.getSelection(true);
+      const at = sel ? sel.index : q.getLength() - 1;
+      q.insertText(at, 'y', 'user');
+      q.setSelection(at + 1);
+      q.root.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          code: 'Enter',
+          keyCode: 13,
+          which: 13,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    // The autocomplete closes and the editor holds exactly the text plus the emoji — no
+    // leftover ':' or shortcode fragment trailing the emoji.
+    await expect(page.getByTestId('emoji-autocomplete')).not.toBeVisible();
+    const editorText = (await editor.textContent()) ?? '';
+    expect(editorText).toContain('😂');
+    expect(editorText).not.toContain(':');
+    expect(editorText).not.toContain('joy');
+    expect(editorText.trim()).toBe('handoff 😂');
+  });
+});


### PR DESCRIPTION
## Problem

Selecting an emoji from the `:shortcode` autocomplete with **Enter** could leave a stray trailing character — e.g. typing a message ending in `:pray` and hitting Enter rendered `…handoff🙏a` (note the leftover `a` after the emoji).

## Cause

`insertEmojiFromAutocomplete` in `frontend/src/hooks/useQuillEditor.ts` computed `deleteLength` from the `emojiQuery` state and read `emojiStartIndex` from its closure. Both lag behind the actually-typed text when the user types quickly and React batches the state updates, so `deleteText` removed fewer characters than were typed — leaving the last typed char as plain text after the inserted emoji.

This is the same bug class as the `@mention` fix in #166.

## Fix

- Read `emojiStartIndex` from a ref (`emojiStartIndexRef`), so it's always current regardless of render batching.
- Derive the span to delete as `sel.index - startIndex` from the **live Quill cursor** instead of from `emojiQuery.length`.

## Test

Adds `frontend/tests/emoji-autocomplete-enter.spec.ts`, a deterministic regression test that reproduces the React-batching race inside a single browser task (insert the final query char, then dispatch Enter before the re-render). It **fails on the old code** (`"handoff 😂y"`) and **passes on the fix**. To drive the race it exposes `window.__quill` in DEV/E2E only, mirroring the existing `window.__socket` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)